### PR TITLE
docs: document GTFS/GTFS-RT system onboarding and add contributor scaffolding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# Contributing
+
+The contributor guide lives at
+[CONTRIBUTING/CONTRIBUTING.md](CONTRIBUTING/CONTRIBUTING.md), with copy-ready
+samples of every hand-written file in
+[CONTRIBUTING/scaffold](CONTRIBUTING/scaffold).

--- a/CONTRIBUTING/CONTRIBUTING.md
+++ b/CONTRIBUTING/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing
+
+Thanks for helping improve PublicTransit.Systems. This guide covers the three
+most common contributions: fixing data on an existing system, adding a new
+system, and wiring up live alerts. The full reference for the data layout and
+every config option is in [data/README.md](../data/README.md). Copy-ready
+samples of every file you would create by hand live in
+[scaffold/](scaffold/).
+
+## Fixing data on an existing system
+
+First check whether the system is generated. If `system.json` has
+`"dataSource": "gtfs"`, then `lines.json`, `stations.json`, and
+`geometry.json` are rebuilt from the agency's feed every night, and edits to
+them will be overwritten. Make your change in `overlay.json` instead: fields
+you set there win over the generated values and survive every refresh. If the
+system has no `dataSource`, it is maintained by hand and you can edit the
+JSON files directly.
+
+If a station or line URL is wrong, the fix usually belongs in `id_map.json`,
+which maps feed ids to our slugs. The map is append only: change where a feed
+id points, never delete entries.
+
+## Adding a new system from GTFS
+
+Most agencies publish a GTFS feed, and for those the system data is generated
+rather than typed in. You create two files by hand and the tooling builds the
+rest.
+
+1. Create the system directory with a `system.json` that sets
+   `"dataSource": "gtfs"` plus the hand-authored fields (name, location,
+   overview, history, stats), and a `gtfs.json` that configures the import.
+   Start from the samples in [scaffold/gtfs-system/](scaffold/gtfs-system/).
+
+2. Download a copy of the agency's GTFS zip and seed the system:
+
+   ```bash
+   pnpm exec tsx scripts/seed-gtfs.ts --system=your-system --zip=path/to/gtfs.zip
+   ```
+
+   This writes `id_map.json`, which pins feed ids to our station and line
+   slugs so URLs stay stable across refreshes, and moves hand-authored fields
+   into `overlay.json`. Read its report before trusting it; it tells you what
+   it could not match.
+
+3. Generate the system and review the output:
+
+   ```bash
+   YOUR_SYSTEM_GTFS_URL=... pnpm run build:gtfs -- --system=your-system
+   ```
+
+4. Pin anything the feed gets wrong (termini naming, topology, colors) in
+   `overlay.json`, regenerate, and repeat until the output looks right. The
+   overlay always wins over generated data. Descriptions, history, ridership,
+   railcars, and stations or lines the feed does not know about all live
+   there too.
+
+5. Add the feed URL as a repository secret and add the system to
+   `.github/workflows/gtfs-nightly.yml` so it refreshes nightly.
+
+OSM enrichment runs automatically for every system and adds station
+identifiers, accessibility features, and entrances. Set
+`"osmEnrichment": false` in `system.json` only if you need to opt out.
+
+## Live alerts from GTFS-RT
+
+Live service alerts and elevator or escalator outages come from the incidents
+worker in `workers/incidents`, which polls each agency on a schedule so the
+app never talks to an agency directly.
+
+If the agency publishes a GTFS-RT service alerts feed, add a fetcher in
+`workers/incidents/src/fetchers.ts` and register it in the `FETCHERS` map in
+`workers/incidents/src/index.ts`. The fetcher decodes the protobuf feed and
+maps the feed's route and stop ids to our line and station slugs. The RTD
+Denver fetcher is a good template: it resolves stops through the system's own
+`id_map.json`, so the realtime side reuses the same mappings as the static
+import. Feeds that need an API key get a bespoke module under
+`workers/incidents/src/systems/` instead; see the WMATA one.
+
+## Systems without a feed
+
+A few agencies publish no GTFS at all. For those, build the JSON files by
+hand and leave `dataSource` unset. `beijing-subway` is the reference
+example, and [scaffold/hand-system/](scaffold/hand-system/) has samples of
+each file. OSM enrichment still covers hand systems: it writes identifiers
+and entrances directly into `stations.json` and never touches entrances you
+wrote yourself.
+
+## Before you open a pull request
+
+```bash
+pnpm run format        # prettier
+pnpm run lint          # eslint
+pnpm run test          # data pipeline unit tests
+pnpm run test:ci       # full build plus accessibility audit
+```
+
+Open an issue first if you are unsure whether a change fits, or if you found
+a data error you cannot fix yourself.

--- a/CONTRIBUTING/scaffold/README.md
+++ b/CONTRIBUTING/scaffold/README.md
@@ -1,0 +1,47 @@
+# Scaffold
+
+Copy-ready samples of every file a contributor writes by hand, using a
+made-up system called `example-metro`. JSON cannot carry comments, so the
+notes live here. The full reference for every option is
+[data/README.md](../../data/README.md).
+
+## gtfs-system/
+
+For agencies that publish a GTFS feed. You hand-write only `system.json` and
+`gtfs.json`; everything else is generated or seeded.
+
+| File                                           | You write it?  | Notes                                                                                                                                                                                                                                                     |
+| ---------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `system.json`                                  | yes            | `"dataSource": "gtfs"` opts the system into generation. Hand fields (overview, history, stats) can start here; the seed script moves them into the overlay.                                                                                               |
+| `gtfs.json`                                    | yes            | Configures the feed import. The sample shows keyless auth; for a keyed feed use `"auth": { "type": "header", "header": "api_key", "value_secret": "YOUR_SYSTEM_API_KEY" }` as in `data/systems/wmata/gtfs.json`. Feed URLs live in secrets, never in git. |
+| `overlay.json`                                 | yes, over time | The hand layer. The sample shows the three entry kinds described below.                                                                                                                                                                                   |
+| `id_map.json`                                  | no             | Written by `scripts/seed-gtfs.ts`, append only. Edit only to fix where a feed id points.                                                                                                                                                                  |
+| `lines.json`, `stations.json`, `geometry.json` | no             | Generated on every refresh. Hand edits will be overwritten.                                                                                                                                                                                               |
+| `osm.json`                                     | no             | Written by the OSM enrichment job.                                                                                                                                                                                                                        |
+
+The sample `overlay.json` demonstrates:
+
+- A **system** section whose fields win over the generated `system.json`.
+- A **decorating** line (`red-line`): its id matches a generated line, so the
+  fields you set override the generated ones field by field. The `topology`
+  object uses `"$replace": true` to swap the whole object instead of merging
+  into it, which is how you pin hand-modeled topology.
+- A **pass-through** line (`loop-line`) and station (`harbor-west`): their
+  ids match nothing in the feed, so they pass through whole. That is how
+  future lines and closed stations survive regeneration. Pass-through
+  entries must be complete (a line needs termini, status, and topology; a
+  station needs lines, status, and coordinates) or the build fails on
+  purpose.
+- Arrays replace wholesale, they do not merge.
+
+## hand-system/
+
+For agencies with no feed. You write all four files and leave `dataSource`
+unset. `data/systems/beijing-subway/` is the real-world reference.
+
+| File            | Notes                                                                                                                          |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `system.json`   | Same shape as the GTFS variant, minus `dataSource`.                                                                            |
+| `lines.json`    | Every line, complete: termini, status, topology, length, station count.                                                        |
+| `stations.json` | Every station. OSM enrichment adds `osmId`, `wikidata`, and entrances in place; it never touches entrances you wrote yourself. |
+| `railcars.json` | Rolling stock generations with specs. Optional but appreciated.                                                                |

--- a/CONTRIBUTING/scaffold/gtfs-system/gtfs.json
+++ b/CONTRIBUTING/scaffold/gtfs-system/gtfs.json
@@ -1,0 +1,18 @@
+{
+  "static": {
+    "url_secret": "EXAMPLE_METRO_GTFS_URL",
+    "auth": { "type": "none" },
+    "filters": {
+      "route_types": [0, 1, 2],
+      "route_ids_exclude": ["SHUTTLE"]
+    },
+    "route_groups": {
+      "red-line": ["RED_NB", "RED_SB"],
+      "blue-line": ["BLU"]
+    },
+    "fields": {
+      "line_name_source": "route_short_name",
+      "line_color_fallback": "#0057B8"
+    }
+  }
+}

--- a/CONTRIBUTING/scaffold/gtfs-system/overlay.json
+++ b/CONTRIBUTING/scaffold/gtfs-system/overlay.json
@@ -1,0 +1,67 @@
+{
+  "system": {
+    "overview": "One or two sentences describing the system: what modes it runs, roughly where, and anything that makes it distinctive.",
+    "stats": {
+      "annualRidership": "22.5 million",
+      "dailyRidership": "68,000"
+    },
+    "history": [
+      {
+        "date": "1979-03-01",
+        "title": "Authority Founded",
+        "description": "The Example Metro Authority was created by the state legislature to plan and operate rail transit in the region."
+      },
+      {
+        "date": "1984-05-12",
+        "title": "Red Line Opens",
+        "description": "The first segment of the Red Line opened between Union Plaza and Airport, with eleven stations."
+      }
+    ]
+  },
+  "lines": {
+    "red-line": {
+      "name": "Red Line",
+      "color": "Red",
+      "colorHex": "#C8102E",
+      "opened": "1984-05-12",
+      "termini": ["Airport", "Harbor East"],
+      "description": "The Red Line is the system's original and busiest line, running from the airport through downtown to the harbor.",
+      "topology": {
+        "$replace": true,
+        "type": "lollipop",
+        "loopStation": "Union Plaza"
+      }
+    },
+    "loop-line": {
+      "id": "loop-line",
+      "systemId": "example-metro",
+      "name": "Loop Line",
+      "color": "Green",
+      "colorHex": "#00843D",
+      "status": "under-construction",
+      "termini": ["Union Plaza"],
+      "topology": { "type": "loop" },
+      "length": 6.2,
+      "stationCount": 9,
+      "description": "The Loop Line is a downtown circulator scheduled to open in 2028. It is not in the agency's feed yet, so this entry passes through the build whole."
+    }
+  },
+  "stations": {
+    "old-town": {
+      "opened": "1984-05-12",
+      "description": "Old Town Station serves the historic district and was the system's first accessible station."
+    },
+    "harbor-west": {
+      "id": "harbor-west",
+      "systemId": "example-metro",
+      "name": "Harbor West",
+      "lines": ["red-line"],
+      "status": "closed",
+      "coordinates": {
+        "lat": 39.271234,
+        "lng": -76.612345
+      },
+      "description": "Harbor West closed in 2003 when the Red Line was rerouted to Harbor East. Closed stations are not in the feed, so this entry passes through the build whole."
+    }
+  }
+}

--- a/CONTRIBUTING/scaffold/gtfs-system/system.json
+++ b/CONTRIBUTING/scaffold/gtfs-system/system.json
@@ -1,0 +1,36 @@
+{
+  "id": "example-metro",
+  "dataSource": "gtfs",
+  "name": "Example Metro Authority",
+  "shortName": "EMA",
+  "location": "Example City, EX",
+  "region": "Example Metro Area",
+  "country": "United States",
+  "opened": "1984-05-12",
+  "website": "https://www.example-metro.gov",
+  "overview": "One or two sentences describing the system: what modes it runs, roughly where, and anything that makes it distinctive.",
+  "stats": {
+    "totalStations": 48,
+    "totalLines": 3,
+    "annualRidership": "22.5 million",
+    "dailyRidership": "68,000",
+    "trackLength": 52.4,
+    "distanceUnit": "mi"
+  },
+  "colors": {
+    "primary": "#0057B8",
+    "secondary": "#FFB81C"
+  },
+  "history": [
+    {
+      "date": "1979-03-01",
+      "title": "Authority Founded",
+      "description": "The Example Metro Authority was created by the state legislature to plan and operate rail transit in the region."
+    },
+    {
+      "date": "1984-05-12",
+      "title": "Red Line Opens",
+      "description": "The first segment of the Red Line opened between Union Plaza and Airport, with eleven stations."
+    }
+  ]
+}

--- a/CONTRIBUTING/scaffold/hand-system/lines.json
+++ b/CONTRIBUTING/scaffold/hand-system/lines.json
@@ -1,0 +1,18 @@
+{
+  "lines": [
+    {
+      "id": "main-line",
+      "systemId": "example-tram",
+      "name": "Main Line",
+      "color": "Purple",
+      "colorHex": "#6B3FA0",
+      "opened": "1927-06-15",
+      "status": "active",
+      "termini": ["Depot Square", "Fairgrounds"],
+      "topology": { "type": "linear" },
+      "length": 8.7,
+      "stationCount": 14,
+      "description": "The Main Line runs from Depot Square through downtown to the fairgrounds, following the route of the original 1927 streetcar."
+    }
+  ]
+}

--- a/CONTRIBUTING/scaffold/hand-system/railcars.json
+++ b/CONTRIBUTING/scaffold/hand-system/railcars.json
@@ -1,0 +1,43 @@
+{
+  "generations": [
+    {
+      "id": "series-100",
+      "systemId": "example-tram",
+      "name": "Series 100",
+      "manufacturer": "Example Rolling Stock Co.",
+      "introduced": 1998,
+      "status": "active",
+      "count": 12,
+      "specs": {
+        "length": "27 m",
+        "width": "2.4 m",
+        "capacity": 180,
+        "seatedCapacity": 64,
+        "maxSpeed": "70 km/h",
+        "carsPerTrain": 1,
+        "traction": "750V DC overhead"
+      },
+      "description": "The Series 100 low-floor trams replaced the original PCC fleet during the 1998 modernization."
+    },
+    {
+      "id": "pcc",
+      "systemId": "example-tram",
+      "name": "PCC",
+      "manufacturer": "St. Louis Car Company",
+      "introduced": 1947,
+      "retired": 1998,
+      "status": "retired",
+      "count": 20,
+      "specs": {
+        "length": "14 m",
+        "width": "2.5 m",
+        "capacity": 90,
+        "seatedCapacity": 54,
+        "maxSpeed": "65 km/h",
+        "carsPerTrain": 1,
+        "traction": "600V DC overhead"
+      },
+      "description": "Secondhand PCC cars carried the line for five decades. One is preserved at the fairgrounds."
+    }
+  ]
+}

--- a/CONTRIBUTING/scaffold/hand-system/stations.json
+++ b/CONTRIBUTING/scaffold/hand-system/stations.json
@@ -1,0 +1,29 @@
+{
+  "stations": [
+    {
+      "id": "depot-square",
+      "systemId": "example-tram",
+      "name": "Depot Square",
+      "lines": ["main-line"],
+      "status": "active",
+      "coordinates": {
+        "lat": 39.123456,
+        "lng": -76.54321
+      },
+      "features": ["fare-vending"],
+      "description": "Depot Square is the western terminus, built on the site of the city's former railroad depot."
+    },
+    {
+      "id": "fairgrounds",
+      "systemId": "example-tram",
+      "name": "Fairgrounds",
+      "lines": ["main-line"],
+      "status": "active",
+      "coordinates": {
+        "lat": 39.134567,
+        "lng": -76.498765
+      },
+      "features": ["fare-vending", "parking"]
+    }
+  ]
+}

--- a/CONTRIBUTING/scaffold/hand-system/system.json
+++ b/CONTRIBUTING/scaffold/hand-system/system.json
@@ -1,0 +1,35 @@
+{
+  "id": "example-tram",
+  "name": "Example City Tramway",
+  "shortName": "ECT",
+  "location": "Example City, EX",
+  "region": "Example Metro Area",
+  "country": "United States",
+  "opened": "1927-06-15",
+  "website": "https://www.example-tram.gov",
+  "overview": "One or two sentences describing the system: what modes it runs, roughly where, and anything that makes it distinctive.",
+  "stats": {
+    "totalStations": 14,
+    "totalLines": 1,
+    "annualRidership": "3.1 million",
+    "dailyRidership": "9,800",
+    "trackLength": 8.7,
+    "distanceUnit": "mi"
+  },
+  "colors": {
+    "primary": "#6B3FA0",
+    "secondary": "#D0D0CE"
+  },
+  "history": [
+    {
+      "date": "1927-06-15",
+      "title": "Tramway Opens",
+      "description": "The original streetcar line opened between Depot Square and the fairgrounds."
+    },
+    {
+      "date": "1998-09-01",
+      "title": "Modernization Complete",
+      "description": "New low-floor vehicles entered service and every stop was rebuilt with level boarding."
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ themselves nightly, with hand-authored content kept in a per-system
 overlay that regeneration never touches. If the agency has no feed, the
 four JSON files can still be written by hand.
 
-See [data/README.md](data/README.md) for the full picture: the data
+See [CONTRIBUTING/CONTRIBUTING.md](CONTRIBUTING/CONTRIBUTING.md) for
+the contributor guide, with copy-ready samples of each hand-written
+file in [CONTRIBUTING/scaffold](CONTRIBUTING/scaffold), and
+[data/README.md](data/README.md) for the full picture: the data
 layers, the gtfs.json configuration reference, the onboarding seeder,
 and the refresh workflows. New systems appear on the home page
 automatically either way.

--- a/src/app/docs/about/page.tsx
+++ b/src/app/docs/about/page.tsx
@@ -48,6 +48,13 @@ export default function AboutPage() {
             <ul className="space-y-2 text-text-secondary">
               <li className="flex items-start gap-2">
                 <span className="text-accent-primary mt-1">•</span>
+                <span>
+                  GTFS feeds published by transit agencies, which generate most system data, and
+                  GTFS-RT feeds, which drive live service alerts
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-accent-primary mt-1">•</span>
                 <span>Official transit authority websites and published statistics</span>
               </li>
               <li className="flex items-start gap-2">
@@ -78,20 +85,85 @@ export default function AboutPage() {
               Help improve PublicTransit.Systems by contributing data, corrections, or code:
             </p>
 
-            <div>
-              <h3 className="font-mono text-sm text-accent-primary mb-2">Adding New Systems</h3>
+            <div className="space-y-3">
+              <h3 className="font-mono text-sm text-accent-primary">
+                Adding a New System from GTFS
+              </h3>
+              <p className="text-sm text-text-secondary">
+                If the agency publishes a GTFS feed, the system data is generated from it rather
+                than written by hand. Create a directory under{" "}
+                <code className="text-accent-secondary">data/systems/</code> containing a{" "}
+                <code className="text-accent-secondary">system.json</code> with{" "}
+                <code className="text-accent-secondary">
+                  &quot;dataSource&quot;: &quot;gtfs&quot;
+                </code>{" "}
+                and a <code className="text-accent-secondary">gtfs.json</code> that configures the
+                import: which secret holds the feed URL, any auth, which route types to keep, and
+                how feed routes group into lines. Then seed the system from a downloaded copy of the
+                feed and run the build:
+              </p>
               <Terminal>
-                <TerminalLine>mkdir -p data/systems/your-system-id</TerminalLine>
-                <TerminalLine>touch data/systems/your-system-id/system.json</TerminalLine>
-                <TerminalLine>touch data/systems/your-system-id/lines.json</TerminalLine>
-                <TerminalLine>touch data/systems/your-system-id/stations.json</TerminalLine>
-                <TerminalLine>touch data/systems/your-system-id/railcars.json</TerminalLine>
+                <TerminalLine>mkdir -p data/systems/your-system</TerminalLine>
+                <TerminalLine>
+                  pnpm exec tsx scripts/seed-gtfs.ts --system=your-system --zip=gtfs.zip
+                </TerminalLine>
+                <TerminalLine>
+                  YOUR_SYSTEM_GTFS_URL=... pnpm run build:gtfs -- --system=your-system
+                </TerminalLine>
               </Terminal>
+              <p className="text-sm text-text-secondary">
+                The seed script writes <code className="text-accent-secondary">id_map.json</code>,
+                which pins feed ids to our station and line slugs so URLs stay stable across
+                refreshes, and it reports anything it could not match. The build then generates{" "}
+                <code className="text-accent-secondary">lines.json</code>,{" "}
+                <code className="text-accent-secondary">stations.json</code>, and{" "}
+                <code className="text-accent-secondary">geometry.json</code>. Do not edit those by
+                hand: they are rebuilt nightly and your changes would be lost. Anything the feed
+                gets wrong, along with descriptions, history, ridership, railcars, and stations or
+                lines the feed does not know about, goes in{" "}
+                <code className="text-accent-secondary">overlay.json</code>. The overlay always wins
+                over generated data and no refresh can touch it. Once the output looks right, add
+                the feed URL as a repository secret and add the system to{" "}
+                <code className="text-accent-secondary">.github/workflows/gtfs-nightly.yml</code> so
+                it refreshes every night.
+              </p>
+            </div>
+
+            <div className="space-y-3">
+              <h3 className="font-mono text-sm text-accent-primary">Live Alerts from GTFS-RT</h3>
+              <p className="text-sm text-text-secondary">
+                Live service alerts and outages come from the incidents worker in{" "}
+                <code className="text-accent-secondary">workers/incidents</code>, which polls each
+                agency on a schedule so the app never talks to an agency directly. If the agency
+                publishes a GTFS-RT service alerts feed, add a fetcher in{" "}
+                <code className="text-accent-secondary">src/fetchers.ts</code> and register it in
+                the <code className="text-accent-secondary">FETCHERS</code> map in{" "}
+                <code className="text-accent-secondary">src/index.ts</code>. The fetcher decodes the
+                protobuf feed and maps the feed&apos;s route and stop ids to our line and station
+                slugs. The RTD Denver fetcher is a good template: it resolves stops through the
+                system&apos;s own <code className="text-accent-secondary">id_map.json</code>, so the
+                realtime side reuses the same id mappings as the static import.
+              </p>
+            </div>
+
+            <div className="space-y-3">
+              <h3 className="font-mono text-sm text-accent-primary">Systems Without a Feed</h3>
+              <p className="text-sm text-text-secondary">
+                A few agencies publish no GTFS at all. For those, build the JSON files by hand the
+                way <code className="text-accent-secondary">beijing-subway</code> does and leave{" "}
+                <code className="text-accent-secondary">dataSource</code> unset.
+              </p>
             </div>
 
             <p className="text-sm text-text-secondary">
-              Follow the schema defined in existing system files. Submit corrections or additions
-              via{" "}
+              The contributor guide lives at{" "}
+              <code className="text-accent-secondary">CONTRIBUTING/CONTRIBUTING.md</code>, with
+              copy-ready samples of every file you would write by hand in{" "}
+              <code className="text-accent-secondary">CONTRIBUTING/scaffold/</code>. The full
+              reference for the data layout, the{" "}
+              <code className="text-accent-secondary">gtfs.json</code> options, and the overlay
+              rules is in <code className="text-accent-secondary">data/README.md</code>. Submit
+              corrections or additions via{" "}
               <a
                 href="https://github.com/imjustafox/publictransit-systems/issues"
                 target="_blank"


### PR DESCRIPTION
The docs/about page now walks through the real pipeline for adding a system (seed, build, overlay, nightly refresh) instead of the old hand-written JSON instructions, and covers wiring GTFS-RT alerts into the incidents worker. New CONTRIBUTING/ directory holds the contributor guide plus copy-ready scaffold samples of every hand-written file, for both GTFS and hand-built systems, with a root CONTRIBUTING.md pointer so GitHub surfaces it on issues and PRs.